### PR TITLE
Update supported python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Version 0.2.0 - Feature release - 2025-05-06
+
+- Removed Python2.7 support
+- Support for Python3.9, 3.10 and 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 0.2.0 - Feature release - 2025-05-06
+## Version 1.1.0 - Feature release - 2025-05-06
 
 - Removed Python2.7 support
 - Support for Python3.9, 3.10 and 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## Version 1.1.0 - Feature release - 2025-05-06
 
 - Removed Python2.7 support
-- Support for Python3.9, 3.10 and 3.11
+- Support for Python3.9, 3.10, 3.11 and 3.12

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,7 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36"],
+  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON39", "PYTHON310", "PYTHON311"],
   "forceConda": false,
   "installCorePackages": true,
-  "installJupyterSupport": false
+  "installJupyterSupport": false,
+  "corePackageSet": "AUTO"
 }

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON39", "PYTHON310", "PYTHON311"],
+  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON39", "PYTHON310", "PYTHON311", "PYTHON312"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false,

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -3,5 +3,5 @@
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false,
-  "corePackageSet": "AUTO"
+  "corePackagesSet": "AUTO"
 }

--- a/jython-processors/holidays/processor.py
+++ b/jython-processors/holidays/processor.py
@@ -32,7 +32,7 @@ def load_or_create_dataframe(file_name, columns):
 
 
 holidays_df = load_or_create_dataframe("holidays_calendar.csv", columns=["country_name","country_iso","date","holiday_reason"])
-holidays_df['date'] = holidays_df['date'].astype('datetime64')
+holidays_df['date'] = holidays_df['date'].astype('datetime64[ns]')
 weekends_df = load_or_create_dataframe("weekend_days.csv", columns=["country_name","country_iso","weekend_day_numbers"])
 
 input_column = params.get('input_column')

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "holidays",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "meta": {
         "supportLevel": "NOT_SUPPORTED",
         "label": "Holidays",


### PR DESCRIPTION
Remove support for python 2.7 for DSS 14.
Add support for more recent python versions, up until 3.11.
3.12 support cannot be added because of a more strict checking in datetypes from pandas (see [this pr](https://github.com/pandas-dev/pandas/issues/47844))
