### PR TITLE
[sc-330818][holidays] Adds supported Python versions 3.13, 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.2.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.13, 3.14
+
 ## Version 1.1.0 - Feature release - 2025-05-06
 
 - Removed Python2.7 support

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,13 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON39", "PYTHON310", "PYTHON311", "PYTHON312"],
+  "acceptedPythonInterpreters": [
+    "PYTHON36",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false,

--- a/plugin.json
+++ b/plugin.json
@@ -1,14 +1,16 @@
 {
-    "id": "holidays",
-    "version": "1.1.0",
-    "meta": {
-        "supportLevel": "NOT_SUPPORTED",
-        "label": "Holidays",
-        "description": "Flag bank holidays in a dataset containing dates, support for over 50 countries",
-        "author": "Dataiku (Liev Garcia)",
-        "icon": "icon-calendar",
-        "licenseInfo": "Apache Software License",
-        "url": "https://www.dataiku.com/product/plugins/holidays/",
-        "tags": ["Data Preparation"]
-    }
+  "id": "holidays",
+  "version": "1.2.0",
+  "meta": {
+    "supportLevel": "NOT_SUPPORTED",
+    "label": "Holidays",
+    "description": "Flag bank holidays in a dataset containing dates, support for over 50 countries",
+    "author": "Dataiku (Liev Garcia)",
+    "icon": "icon-calendar",
+    "licenseInfo": "Apache Software License",
+    "url": "https://www.dataiku.com/product/plugins/holidays/",
+    "tags": [
+      "Data Preparation"
+    ]
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: `NOT_SUPPORTED`
- Added supported Python versions: `3.13, 3.14`
- Bumped plugin version: `1.2.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅